### PR TITLE
Fixes #32

### DIFF
--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -26,7 +26,7 @@ export class Platform extends HomebridgePlatform<Configuration> {
      * Gets the name of the plugin.
      */
     public get pluginName(): string {
-        return 'homebridge-appletv';
+        return 'homebridge-apple-tv-remote';
     }    
     
     /**


### PR DESCRIPTION
-  Fixes Issue #32: `Plugin 'homebridge-apple-tv-remote' tried to register with an incorrect plugin identifier: 'homebridge-appletv'. Please report this to the developer!`