### PR TITLE
Add API support for current app 

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ npm install -g homebridge-apple-tv-remote
 
 **name**: The name of the Play Pause button. 
 
-**bundleIdentifier**: The technical name of an app on the AppleTV. This value is reported in the debug information of the plugin. examples: "com.netflix.Netflix" or "com.google.ios.youtube"
+**bundleIdentifier**: The technical name of an app on the Apple TV. This value is reported in the debug information of the plugin. Known bundleIdentifier: "com.netflix.Netflix", "com.google.ios.youtube" and the default apps of the Apple TV: https://support.apple.com/en-us/guide/mdm/mdmc90dce69e/web Please be aware this value is case sensitive. 
 
 **commandSwitches** (optional): You can provide a list of switches that should be additionally exposed to HomeKit. Those switches are "stateless" and execute the configured commands.
 
@@ -158,6 +158,7 @@ The response body will be JSON:
 {
     "isOn": true|false,
     "isPlaying": true|false
+    "currentApp": "<bundleIdentifier>"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,19 @@ npm install -g homebridge-apple-tv-remote
 
 **name**: The name of the Play Pause button. 
 
-**bundleIdentifier**: The technical name of an app on the Apple TV. This value is reported in the debug information of the plugin. Known bundleIdentifier: "com.netflix.Netflix", "com.google.ios.youtube" and the default apps of the Apple TV: https://support.apple.com/en-us/guide/mdm/mdmc90dce69e/web Please be aware this value is case sensitive. 
+**bundleIdentifier**: The technical name of an app on the Apple TV. This value is reported in the log information of the plugin. This value is case sensitive.
+
+Known bundleIdentifier:  
+* `com.netflix.Netflix`
+* `com.google.ios.youtube`
+* `com.apple.TVWatchList`
+* `com.amazon.aiv.AIVApp`
+* `com.disney.disneyplus`
+* `com.apple.TVMusic`
+* `com.apple.TVAirPlay`
+* `com.spotify.client`
+
+Default app bundleIdentifiers can be found here: https://support.apple.com/en-us/guide/mdm/mdmc90dce69e/web
 
 **commandSwitches** (optional): You can provide a list of switches that should be additionally exposed to HomeKit. Those switches are "stateless" and execute the configured commands.
 

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -69,6 +69,7 @@ export class Api {
             const appleTv = new AppleTv();
             appleTv.isOn = await client.isOnAsync();
             appleTv.isPlaying = await client.isPlayingAsync();
+            appleTv.currentApp = await client.getCurrentAppAsync();
 
             // Checks if disconnection is needed (in case events are disabled)
             if (!client.areEventsEnabled) {

--- a/src/lib/api/models/apple-tv.ts
+++ b/src/lib/api/models/apple-tv.ts
@@ -17,6 +17,11 @@ export class AppleTv {
     public isPlaying?: boolean;
 
     /**
+     * Gets or sets a value that determines which app the Apple TV is playing.
+     */
+    public currentApp?: string;
+
+    /**
      * Gets or sets a list of commands that should be executed.
      */
     public commands?: Array<Command>;

--- a/src/lib/clients/apple-tv-client.ts
+++ b/src/lib/clients/apple-tv-client.ts
@@ -160,6 +160,7 @@ export class AppleTvClient extends EventEmitter {
                             // Updates current app
                             if(m.payload.playerPath?.client?.bundleIdentifier){
                                 this._currentApp = currentApp;
+                                this.platform.logger.info(`[${this.name}] Current bundleIdentifier is now: ${m.payload.playerPath?.client?.bundleIdentifier}`);
                             }
                         
                             // Updates the play state

--- a/src/lib/clients/apple-tv-client.ts
+++ b/src/lib/clients/apple-tv-client.ts
@@ -164,9 +164,7 @@ export class AppleTvClient extends EventEmitter {
                         
                             // Updates the play state
                             this.updateIsPlaying(this.getIsPlaying(m.payload));
-                        }
-                           
-
+                        } 
                     }
                 });
             }
@@ -439,6 +437,22 @@ export class AppleTvClient extends EventEmitter {
             this.updateIsPlayingTimeoutHandle = null;
         }, this.platform.configuration.isPlayingDampeningTimeout * 1000);
     }
+
+    /**
+     * Gets a value that determines whether the Apple TV is playing.
+     * @param retryCount The number of retries that are left.
+     */
+    public async getCurrentAppAsync(): Promise<string> {
+        this.platform.logger.info(`[${this.name}] Getting current app...`);
+
+        // If events are enabled, the value is already cached
+        if (this.areEventsEnabled) {
+            this.platform.logger.info(`[${this.name}] Returning cached value ${this.currentApp} for current app`);
+            return this.currentApp;
+        } else {
+            return ''
+        }
+    };
 
     /**
      * Gets a value that determines whether the Apple TV is playing.


### PR DESCRIPTION
Add support for the API to return the current app that is stored in the client.currentApp. 

https://github.com/lukasroegner/homebridge-apple-tv-remote/issues/62